### PR TITLE
Add middleware support to backend

### DIFF
--- a/Backend/cmd/main/main.go
+++ b/Backend/cmd/main/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"log"
 	"net/http"
+
+	"github.com/2024-CMPU9010-GROUP-3/PROJECT/internal/middleware"
 )
 
 func handleRequest(w http.ResponseWriter, r *http.Request) {
-	log.Println("Received request!")
 	w.Write([]byte("World!"))
 }
 
@@ -14,9 +15,13 @@ func main() {
 	router := http.NewServeMux()
 	router.HandleFunc("/hello", handleRequest)
 
+	middlewares := middleware.CreateMiddlewareStack(
+		middleware.Logging,
+	)
+
 	server := http.Server{
 		Addr:    ":8080",
-		Handler: router,
+		Handler: middlewares(router),
 	}
 
 	log.Println("Listening on port 8080")

--- a/Backend/internal/middleware/logging.go
+++ b/Backend/internal/middleware/logging.go
@@ -1,0 +1,35 @@
+// This is a simple logging middleware for demonstration purposes
+// created following this tutorial by DreamsOfCode on YouTube https://www.youtube.com/watch?v=H7tbjKFSg58
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type StatusCodeWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (w *StatusCodeWriter) WriteHeader(statusCode int) {
+	w.ResponseWriter.WriteHeader(statusCode)
+	w.statusCode = statusCode
+}
+
+func Logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		startTime := time.Now()
+
+		statusCodeWriter := &StatusCodeWriter{
+			ResponseWriter: writer,
+			statusCode:     http.StatusOK,
+		}
+
+		next.ServeHTTP(statusCodeWriter, request)
+
+		log.Println(statusCodeWriter.statusCode, request.Method, request.URL.Path, time.Since(startTime))
+
+	})
+}

--- a/Backend/internal/middleware/middleware.go
+++ b/Backend/internal/middleware/middleware.go
@@ -1,0 +1,18 @@
+// created following this tutorial by DreamsOfCode on YouTube https://www.youtube.com/watch?v=H7tbjKFSg58
+package middleware
+
+import "net/http"
+
+type Middleware func(http.Handler) http.Handler
+
+// This function creates a linked list of functions of the given middlewares and returns a reference to the first function
+// Any HTTP request passed to the first function is passed to all middlewares in the order they were provided to this function
+func CreateMiddlewareStack(middlewares ...Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		for i := len(middlewares) - 1; i >= 0; i-- {
+			middleware := middlewares[i]
+			next = middleware(next)
+		}
+		return next
+	}
+}

--- a/Backend/readme.md
+++ b/Backend/readme.md
@@ -1,8 +1,10 @@
 # Backend
 
+This is a backend written in Go using the net/http package of the standard library. The server is equipped with a middleware that will log the URL, status code and response time of any request to std out.
+
 ## Usage
 
-There are two options to run the backend, either locally or using Docker.
+There are two options to run the backend, either locally or using Docker. 
 
 ### Run in Docker
 
@@ -19,7 +21,7 @@ docker build -t cmpu9010-backend .
 Then run the container with the following command:
 
 ```
-docker run cmpu9010-backend -p 8080:8080
+docker run -p 8080:8080 cmpu9010-backend
 ```
 
 The server will then be reachable on `localhost:8080`
@@ -42,7 +44,7 @@ The server will then be reachable on `localhost:8080`
 
 #### `GET` `/hello`
 
-**Parameters:** None
-**Accepts:** None
-**Response:** Plaintext
-This route returns _"World!"_ when queried to show the server is working and accepting requests.
+- **Parameters:** None  
+- **Accepts:** None  
+- **Response:** Plaintext  
+- **Description:** This route returns _"World!"_ when queried to show the server is working and accepting requests.  


### PR DESCRIPTION
### Description

Adds provisioning for middleware and a simple logging middleware to the backend. The setup allows for the simple chaining of multiple middlewares in the future.

Fixes # (issue)

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Changes

- Added a middleware type
- Added a function to create a chained stack of middlewares
- Added a simple logging middleware that logs information about all incoming requests to std out
- Updated documentation: fixed order of parameters in docker run command
