### PR TITLE
Added a loader animation to homepage

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -26,6 +26,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
+    "react-loader-spinner": "^6.1.6",
     "react-map-gl": "^7.1.7",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"

--- a/Frontend/src/app/components/map/MapboxMap.tsx
+++ b/Frontend/src/app/components/map/MapboxMap.tsx
@@ -14,11 +14,12 @@ import { IconHome } from "@tabler/icons-react";
 import { Slider } from "@/components/ui/slider";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
+import { Grid } from "react-loader-spinner";
 
 type SliderProps = React.ComponentProps<typeof Slider>;
 
 const LocationAggregatorMap = ({ className, ...props }: SliderProps) => {
-  const [mapBoxApiKey, setMapBoxApiKey] = useState<string>('');
+  const [mapBoxApiKey, setMapBoxApiKey] = useState<string>("");
 
   const [coordinates, setCoordinates] = useState<Coordinates>({
     latitude: 0,
@@ -43,7 +44,7 @@ const LocationAggregatorMap = ({ className, ...props }: SliderProps) => {
   useEffect(() => {
     // Fetch Mapbox API key from the server
     const fetchMapboxKey = async () => {
-      const response = await fetch('/api/mapbox-token');
+      const response = await fetch("/api/mapbox-token");
       const data = await response.json();
       setMapBoxApiKey(data.mapBoxApiKey);
     };
@@ -152,7 +153,18 @@ const LocationAggregatorMap = ({ className, ...props }: SliderProps) => {
           </Map>
         </DeckGL>
       ) : (
-        <div>Loading...</div>
+        <div className="absolute top-1/2 right-1/2">
+          <Grid
+            visible={true}
+            height="80"
+            width="80"
+            color="#ffa15a"
+            ariaLabel="grid-loading"
+            radius="12.5"
+            wrapperStyle={{}}
+            wrapperClass="grid-wrapper"
+          />
+        </div>
       )}
       <div className="absolute bg-transparent top-20 right-32 scale-125 transition-all">
         <div className="2xl:min-w-[200px] 2xl:max-w-[300px] bg-white rounded-xl ">


### PR DESCRIPTION
### Description

Now the homepage has a loader when the map is not yet loaded.

Fixes #73 

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Added a grid animation loader when no map is displayed on the homepage
