### PR TITLE
distribution/kubernetes fix

### DIFF
--- a/Distribution/kubernetes/Magpie/magpie/app/backend/private/deployment.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/backend/private/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: private-backend
     spec:
       containers:
-        - name: flood
+        - name: private-backend
           image: ghcr.io/2024-cmpu9010-group-3/backend-private:0.2.1@sha256:c624444e50f1d012cc42e4870c8833913ee5446241143f3adeaa6684178f6075
           resources: {}
           ports:

--- a/Distribution/kubernetes/Magpie/magpie/app/backend/public/deployment.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/backend/public/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: public-backend
     spec:
       containers:
-        - name: flood
+        - name: public-backend
           image: ghcr.io/2024-cmpu9010-group-3/backend-public:0.2.1@sha256:3a4080ff6453daa23bab68dc54e19b5f4ceb9e27c5155bd12be1a92482012dcb
           resources: {}
           ports:

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/deployment.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           image: ghcr.io/2024-cmpu9010-group-3/frontend:0.1.0@sha256:fc0a5476f7e3797c788e4b3f1994f8576cf9b469e0019a09c77b57050895a24b
           resources: {}
           ports:
-            - containerPort: 80
+            - containerPort: 3000
           env:
             - name: NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
               valueFrom:

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/deployment.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: frontend
     spec:
       containers:
-        - name: flood
+        - name: frontend
           image: ghcr.io/2024-cmpu9010-group-3/frontend:0.1.0@sha256:fc0a5476f7e3797c788e4b3f1994f8576cf9b469e0019a09c77b57050895a24b
           resources: {}
           ports:

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/headers.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/headers.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: default-headers
+spec:
+  headers:
+    browserXssFilter: true
+    contentTypeNosniff: true
+    forceSTSHeader: true
+    stsIncludeSubdomains: true
+    stsPreload: true
+    stsSeconds: 15552000
+    customFrameOptionsValue: SAMEORIGIN
+    customRequestHeaders:
+      X-Forwarded-Proto: https

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/ingress.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/ingress.yaml
@@ -1,0 +1,21 @@
+---
+    apiVersion: traefik.io/v1alpha1
+    kind: IngressRoute
+    metadata:
+      name: frontend-ingress
+      annotations:
+        kubernetes.io/ingress.class: traefik-external
+    spec:
+      entryPoints:
+        - websecure
+      routes:
+        - match: Host(`magpie.solonsstuff.com`)
+          kind: Rule
+          services:
+            - name: frontend-service
+              port: 80
+          middlewares:
+            - name: default-headers
+      tls:
+        secretName: solonsstuff-com-live-tls
+    

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/kustomization.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
+- headers.yaml
+- ingress.yaml
 - secret.yaml
 - service.yaml

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/service.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/service.yaml
@@ -9,4 +9,4 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 3000

--- a/Distribution/kubernetes/Magpie/magpie/install.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/install.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: magpie
-  path: "./kubernetes/Magpie/magpie/app"
+  path: "./Distribution/kubernetes/Magpie/magpie/app"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/Distribution/kubernetes/Magpie/magpie/install.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/install.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: magpie
-  path: "./kubernetes/projects/Magpie/magpie/app"
+  path: "./Distribution/kubernetes/Magpie/magpie/app"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/Distribution/kubernetes/Magpie/magpie/install.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/install.yaml
@@ -9,11 +9,11 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: magpie
-  path: "./kubernetes/magpie/magpie/app"
+  path: "./Distribution/kubernetes/magpie/magpie/app"
   prune: true
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: 2024-cmpu9010-group-3
   decryption:
     provider: sops
     secretRef:

--- a/Distribution/kubernetes/Magpie/magpie/install.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/install.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: magpie
-  path: "./kubernetes/Magpie/magpie/app"
+  path: "./kubernetes/magpie/magpie/app"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/Distribution/kubernetes/Magpie/magpie/install.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/install.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: magpie
-  path: "./Distribution/kubernetes/Magpie/magpie/app"
+  path: "./kubernetes/Magpie/magpie/app"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/Distribution/kubernetes/Magpie/magpie/install.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/install.yaml
@@ -9,7 +9,7 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: magpie
-  path: "./Distribution/kubernetes/magpie/magpie/app"
+  path: "./kubernetes/Magpie/magpie/app"
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
### Description

The previous kubernetes deployment targeted both the wrong directory, and chose the wrong source. Both of these have been corrected.

Additionally, the reverse proxy has been provisioned and the frontend is now accessible at [magpie.solonsstuff.com!](https://magpie.solonsstuff.com/)

### **IMPORTANT**

While the reverse proxy and the headers I've set should secure the app for the moment, we still have several things we need to discuss related to securing the frontend and (in particular) the mapbox api key.

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- **Shifts directory to "./Distribution/kubernetes/Magpie/magpie/app"**
- **Changes container names to better reflect their task, rather then my template**
- **Adjusts service to target port 3000 over 80, as that's currently the default for the backend**
- **Adds headers for reverse proxy**
- **Provisions reverse proxy**
- **Updates kustomize to apply the rest of the frontend yaml**
