### PR TITLE
Adds missing instruction for database setup in backend readme

### DIFF
--- a/Backend/readme.md
+++ b/Backend/readme.md
@@ -16,7 +16,7 @@ Both backends need a single PostgreSQL database with the PostGIS extension to be
 docker run --name some-postgis -e POSTGRES_PASSWORD=mysecretpassword -d -p 5432:5432 postgis/postgis
 ```
 
-- Initialise the database with the SQL scripts in `/Backend/sql/schema.sql` using a database access tool like DBeaver.
+- Initialise the database with the SQL scripts in `/Backend/sql/extensions.sql` and `/Backend/sql/schema.sql` using a database access tool like DBeaver.
   _**Note**: The schema setup process will be automated in the future, but for now it has to be done manually._
 
 - Set the environment variables according to [this](#configuration).


### PR DESCRIPTION
### Description

This PR adds a missing instruction to the database setup in the backend readme

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Changes

- Added instruction to run `extensions.sql` before running the schema file
