### PR TITLE
Updates build actions to remove `/n` and `/r` from version input

### DIFF
--- a/.github/workflows/backend-private-build.yaml
+++ b/.github/workflows/backend-private-build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Extract package version
         id: get_version
         run: |
-          VERSION=$(cat Backend/.version)
+          VERSION=$(cat Backend/.version | tr -d '\n' | tr -d '\r')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Push Docker image to GitHub Container Registry

--- a/.github/workflows/backend-public-build.yaml
+++ b/.github/workflows/backend-public-build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Extract package version
         id: get_version
         run: |
-          VERSION=$(cat Backend/.version)
+          VERSION=$(cat Backend/.version | tr -d '\n' | tr -d '\r')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Push Docker image to GitHub Container Registry

--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Extract package version
         id: get_version
         run: |
-          VERSION=$(jq -r '.version' Frontend/package.json)
+          VERSION=$(jq -r '.version' Frontend/package.json | tr -d '\n' | tr -d '\r')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Push Docker image to GitHub Container Registry


### PR DESCRIPTION
### Description

The backend build for #172 [failed](https://github.com/2024-CMPU9010-GROUP-3/PROJECT/actions/runs/11368474720/workflow) due to a carriage return in the `.version` file. This PR sanitises the input for the version tag.

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
