### PR TITLE
Adds macOS .DS_STORE to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ language-server-log.txt
 
 # Don't commit secrets to repo
 .env
+
+# Ignore macOS directory attributes file
+.DS_STORE


### PR DESCRIPTION
### Description

This PR adds `.DS_STORE` to the global `.gitignore` file.
`.DS_Store` files are a hidden system file created by macOS to store custom attributes and metadata, such as folder view settings and icon positions, for the files within a directory.

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Added .DS_STORE to global `.gitignore`
