### PR TITLE
Adjusts and renames byRadius route to inEnvelope route

### DIFF
--- a/Backend/internal/handlers/points_public.go
+++ b/Backend/internal/handlers/points_public.go
@@ -23,26 +23,21 @@ type pointDto struct {
 	Type    db.PointType
 }
 
-func (p *PointsHandler) HandleGetByRadius(w http.ResponseWriter, r *http.Request) {
+func (p *PointsHandler) HandleGetInEnvelope(w http.ResponseWriter, r *http.Request) {
 	// parameters long, lat, radius are required
 	params := r.URL.Query()
-	long, err_long := strconv.ParseFloat(params.Get("long"), floatPrecision)
-	lat, err_lat := strconv.ParseFloat(params.Get("lat"), floatPrecision)
-	radius, err_radius := strconv.ParseFloat(params.Get("radius"), floatPrecision)
+	long1, err_long1 := strconv.ParseFloat(params.Get("long1"), floatPrecision)
+	lat1, err_lat1 := strconv.ParseFloat(params.Get("lat1"), floatPrecision)
+	long2, err_long2 := strconv.ParseFloat(params.Get("long2"), floatPrecision)
+	lat2, err_lat2 := strconv.ParseFloat(params.Get("lat2"), floatPrecision)
 
 	// bad request if any parameters can't be parsed to float
-	if err_long != nil || err_lat != nil || err_radius != nil {
+	if err_long1 != nil || err_lat1 != nil || err_long2 != nil || err_lat2 != nil {
 		resp.SendError(customErrors.Parameter.InvalidFloatError, w)
 		return
 	}
 
-	// construct envelope
-	x1 := long - radius
-	y1 := lat - radius
-	x2 := long + radius
-	y2 := lat + radius
-
-	points, err := db.New(dbConn).GetPointsInEnvelope(*dbCtx, db.GetPointsInEnvelopeParams{X1: x1, Y1: y1, X2: x2, Y2: y2})
+	points, err := db.New(dbConn).GetPointsInEnvelope(*dbCtx, db.GetPointsInEnvelopeParams{X1: long1, Y1: lat1, X2: long2, Y2: lat2})
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			resp.SendError(customErrors.Database.UnknownDatabaseError.WithCause(err), w)

--- a/Backend/internal/routes/routes_public.go
+++ b/Backend/internal/routes/routes_public.go
@@ -27,7 +27,7 @@ func pointsPublic() *http.ServeMux {
 	pointsHandler := &handlers.PointsHandler{}
 
 	// Authenticated access
-	router.Handle("GET /byRadius", middleware.Access.Authenticated(http.HandlerFunc(pointsHandler.HandleGetByRadius)))
+	router.Handle("GET /inEnvelope", middleware.Access.Authenticated(http.HandlerFunc(pointsHandler.HandleGetInEnvelope)))
 	router.Handle("GET /{id}", middleware.Access.Authenticated(http.HandlerFunc(pointsHandler.HandleGetPointDetails)))
 
 	return router

--- a/Backend/routes-public.md
+++ b/Backend/routes-public.md
@@ -55,14 +55,14 @@ There are currently three different route access levels for public routes in the
 
 ## Points
 
-### `GET` `/v1/public/points/byRadius?long={}&lat={}&radius={}`
+### `GET` `/v1/public/points/inEnvelope?long1={}&lat1={}&long2={}&lat2={}`
 
 - **Access:** `authenticated`
 - **Path Parameters:** None
-- **Query Parameters:** Longitude, Latitude, Radius
+- **Query Parameters:** Longitude 1, Latitude 1, Longitude 2, Latitude 2
 - **Accepts:** None
 - **Response:** JSON (List of points)
-- **Description:** This route returns all points in a square with a given radius around the given latitude and longitude
+- **Description:** This route returns all points in rectangle defined by the two given corners (top left, bottom right)
 
 ### `GET` `/v1/public/points/{id}`
 


### PR DESCRIPTION
### Description

This PR changes the `byRadius` route into `inEnvelope`. This allows the frontend to search for points by sending a set of two coordinates that define a box on the map.

Fixes #217 

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Changes

- Renamed `byRadius` to `inEnvelope`
- Changed the expected parameters to two sets of longitude and latitude
- Updated documentation
