### PR TITLE
Adds parking as point type, removes placeholders

### DIFF
--- a/Backend/internal/db/private/models.go
+++ b/Backend/internal/db/private/models.go
@@ -17,8 +17,7 @@ import (
 type PointType string
 
 const (
-	PointTypePlaceholder1 PointType = "placeholder1"
-	PointTypePlaceholder2 PointType = "placeholder2"
+	PointTypeParking PointType = "parking"
 )
 
 func (e *PointType) Scan(src interface{}) error {

--- a/Backend/internal/db/public/models.go
+++ b/Backend/internal/db/public/models.go
@@ -17,8 +17,7 @@ import (
 type PointType string
 
 const (
-	PointTypePlaceholder1 PointType = "placeholder1"
-	PointTypePlaceholder2 PointType = "placeholder2"
+	PointTypeParking PointType = "parking"
 )
 
 func (e *PointType) Scan(src interface{}) error {

--- a/Backend/sql/schema.sql
+++ b/Backend/sql/schema.sql
@@ -1,4 +1,4 @@
-CREATE TYPE point_type AS ENUM ('placeholder1', 'placeholder2');
+CREATE TYPE point_type AS ENUM ('parking');
 
 CREATE TABLE points (
   Id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
### Description

This PR removes the placeholder types from the database schema and adds the type `parking`.
This is a breaking change as it is necessary to drop the type `point_type` and the table `points` from the database and re-run two SQL statements for creating the two in `schema.sql`.

Fixes #219 

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Removed types `placeholder1` and `placeholder2` from the `point_type` enum
- Added type `parking` to `point_type` enum
